### PR TITLE
fix healthcheck bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ EXPOSE 5000
 
 # healthcheck localhost:$DYNDNS_LISTEN_ADDR/ping (default 5000)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s \
-  CMD /curl -f http://localhost:5000/ping || exit 1
+  CMD curl -f http://localhost:5000/ping || exit 1
 
 # Run
 CMD ["/cloudflare-updater"]


### PR DESCRIPTION
The Dockerfile-provided health check did not work, due to `curl` being written with a leading `/`, while it's not placed in the root directory.

This PR removes that `/` and fixes the call to `curl`.